### PR TITLE
Allow to use m2r2 extension instead of commonmark to format tables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ USER root
 RUN pip install \
   Sphinx==2.4.4 \
   sphinxcontrib-confluencebuilder \
-  recommonmark
+  recommonmark \
+  m2r2
 
 COPY entrypoint entrypoint
 


### PR DESCRIPTION
I was using originally using the following to include markdown files in confluence:
```
source_parsers = {
   '.md': 'recommonmark.parser.CommonMarkParser',
}
```

I needed to switch to m2r2 for using tables as in github:
```
| Headers           | Headers           | Headers           |
| ----------------- | ----------------- | ----------------- |
| rows              | rows              | rows              |
```

This is the conf.py I used:
```
# source_parsers = {
#   '.md': 'recommonmark.parser.CommonMarkParser',
# }
extensions = [
  'sphinxcontrib.confluencebuilder',
  'm2r2',
]
```
