### PR TITLE
Add requirements file as an optional parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ USER root
 RUN pip install \
   Sphinx==2.4.4 \
   sphinxcontrib-confluencebuilder \
-  bai2 \
-  pyyaml \
   recommonmark \
   m2r2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ USER root
 RUN pip install \
   Sphinx==2.4.4 \
   sphinxcontrib-confluencebuilder \
+  bai2 \
   recommonmark \
   m2r2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN pip install \
   Sphinx==2.4.4 \
   sphinxcontrib-confluencebuilder \
   bai2 \
+  pyyaml \
   recommonmark \
   m2r2
 

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ to be added to the Github repo.
         with:
           username: ${{ secrets.atlassianUsername }}
           apitoken: ${{ secrets.atlassianApitoken }}
-          requirements_file: ${{ secrets.atlassianApitoken }}
+          requirementsfile: custom_requirements.txt
 
 .. _confluencebuilder: https://github.com/sphinx-contrib/confluencebuilder
 .. _Github secrets: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ to be added to the Github repo.
         with:
           username: ${{ secrets.atlassianUsername }}
           apitoken: ${{ secrets.atlassianApitoken }}
-          requirementsfile: custom_requirements.txt
+          requirementsfile: custom_requirements.txt  # this is an optional parameter
 
 .. _confluencebuilder: https://github.com/sphinx-contrib/confluencebuilder
 .. _Github secrets: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,7 @@ to be added to the Github repo.
         with:
           username: ${{ secrets.atlassianUsername }}
           apitoken: ${{ secrets.atlassianApitoken }}
+          requirements_file: ${{ secrets.atlassianApitoken }}
 
 .. _confluencebuilder: https://github.com/sphinx-contrib/confluencebuilder
 .. _Github secrets: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets

--- a/action.yaml
+++ b/action.yaml
@@ -11,7 +11,7 @@ inputs:
   docsdir:
     description: 'directory in the repo where the docs are located'
     default: ''
-  requirementfile:
+  requirementsfile:
     description: 'file at base of the directory if it not requirements.txt'
     default: ''
 runs:

--- a/action.yaml
+++ b/action.yaml
@@ -11,6 +11,9 @@ inputs:
   docsdir:
     description: 'directory in the repo where the docs are located'
     default: ''
+  requirementfile:
+    description: 'file at base of the directory if it not requirements.txt'
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint
+++ b/entrypoint
@@ -1,8 +1,8 @@
 #!/bin/sh -l
 
 # install requirements.txt if it exists
-if [  -z "$INPUT_REQUIREMENTS_FILE" ]; then
-  pip install --user -r $INPUT_REQUIREMENTS_FILE
+if [  -z "$INPUT_REQUIREMENTSFILE" ]; then
+  pip install --user -r $INPUT_REQUIREMENTSFILE
 elif [ -f requirements.txt ]; then
   pip install --user -r requirements.txt
 fi

--- a/entrypoint
+++ b/entrypoint
@@ -1,7 +1,7 @@
 #!/bin/sh -l
 
 # install requirements.txt if it exists
-if [  -z "$INPUT_REQUIREMENTSFILE" ]; then
+if [[ "$INPUT_REQUIREMENTSFILE" ]]; then
   pip install --user -r $INPUT_REQUIREMENTSFILE
 elif [ -f requirements.txt ]; then
   pip install --user -r requirements.txt

--- a/entrypoint
+++ b/entrypoint
@@ -1,8 +1,8 @@
 #!/bin/sh -l
 
 # install requirements.txt if it exists
-if [ -f requirements.txt ]; then
-  pip install --user -r requirements.txt
+if [ -f confluence_requirements.txt ]; then
+  pip install --user -r confluence_requirements.txt
 fi
 
 if ! [ -z "$INPUT_DOCSDIR" ]; then

--- a/entrypoint
+++ b/entrypoint
@@ -1,7 +1,7 @@
 #!/bin/sh -l
 
 # install requirements.txt if it exists
-if [[ $INPUT_REQUIREMENTS_FILE ]]; then
+if [  -z "$INPUT_REQUIREMENTS_FILE" ]; then
   pip install --user -r $INPUT_REQUIREMENTS_FILE
 elif [ -f requirements.txt ]; then
   pip install --user -r requirements.txt

--- a/entrypoint
+++ b/entrypoint
@@ -1,7 +1,7 @@
 #!/bin/sh -l
 
 # install requirements.txt if it exists
-if [[ "$INPUT_REQUIREMENTSFILE" ]]; then
+if [ "$INPUT_REQUIREMENTSFILE" ]; then
   pip install --user -r $INPUT_REQUIREMENTSFILE
 elif [ -f requirements.txt ]; then
   pip install --user -r requirements.txt

--- a/entrypoint
+++ b/entrypoint
@@ -4,5 +4,7 @@ if ! [ -z "$INPUT_DOCSDIR" ]; then
   cd $INPUT_DOCSDIR
 fi
 
+echo "$INPUT_USERNAME $INPUT_APITOKEN"
+
 make confluence \
   SPHINXOPTS="-D confluence_server_user=$INPUT_USERNAME -D confluence_server_pass=$INPUT_APITOKEN"

--- a/entrypoint
+++ b/entrypoint
@@ -1,10 +1,5 @@
 #!/bin/sh -l
 
-# install requirements.txt if it exists
-if [ -f confluence_requirements.txt ]; then
-  pip install --user -r confluence_requirements.txt
-fi
-
 if ! [ -z "$INPUT_DOCSDIR" ]; then
   cd $INPUT_DOCSDIR
 fi

--- a/entrypoint
+++ b/entrypoint
@@ -4,7 +4,5 @@ if ! [ -z "$INPUT_DOCSDIR" ]; then
   cd $INPUT_DOCSDIR
 fi
 
-echo "$INPUT_USERNAME $INPUT_APITOKEN"
-
 make confluence \
   SPHINXOPTS="-D confluence_server_user=$INPUT_USERNAME -D confluence_server_pass=$INPUT_APITOKEN"

--- a/entrypoint
+++ b/entrypoint
@@ -1,5 +1,12 @@
 #!/bin/sh -l
 
+# install requirements.txt if it exists
+if [[ $INPUT_REQUIREMENTS_FILE ]]; then
+  pip install --user -r $INPUT_REQUIREMENTS_FILE
+elif [ -f requirements.txt ]; then
+  pip install --user -r requirements.txt
+fi
+
 if ! [ -z "$INPUT_DOCSDIR" ]; then
   cd $INPUT_DOCSDIR
 fi


### PR DESCRIPTION
Wanted to be able to pip install additional directories, without having to name the file requirements.txt because the repo already had it defined. This change will allow users to pass in the requirements.txt file in as a parameter, and not have to change how files are named in their current repo.